### PR TITLE
feat(structure): initial implementation of OpenXR camera rig

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2e799175235e9f0449f95908d4b20eea
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation.meta
+++ b/Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 375e1d1e91fb5554a908cc75d181f63d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API.meta
+++ b/Documentation/API.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e850df35680eec439ba1f4a5b4d96de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/BasePassthroughManager.md
+++ b/Documentation/API/BasePassthroughManager.md
@@ -1,0 +1,63 @@
+# Class BasePassthroughManager
+
+The base class for a Passthrough Manager
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [ActivatePassthrough()]
+  * [DeactivatePassthrough()]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* BasePassthroughManager
+* [PassthroughManager]
+* [PassthroughProcessor]
+
+##### Namespace
+
+* [Tilia.CameraRigs.OpenXR]
+
+##### Syntax
+
+```
+public abstract class BasePassthroughManager : MonoBehaviour
+```
+
+### Methods
+
+#### ActivatePassthrough()
+
+Activates the passthrough mode if available.
+
+##### Declaration
+
+```
+public abstract void ActivatePassthrough()
+```
+
+#### DeactivatePassthrough()
+
+Deactivates the passthrough mode if available.
+
+##### Declaration
+
+```
+public abstract void DeactivatePassthrough()
+```
+
+[PassthroughManager]: PassthroughManager.md
+[PassthroughProcessor]: PassthroughProcessor.md
+[Tilia.CameraRigs.OpenXR]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[ActivatePassthrough()]: #ActivatePassthrough
+[DeactivatePassthrough()]: #DeactivatePassthrough

--- a/Documentation/API/BasePassthroughManager.md.meta
+++ b/Documentation/API/BasePassthroughManager.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 27cbe644ffa51fb4dba1b566a991fd6e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/OpenXRNodeRecord.md
+++ b/Documentation/API/OpenXRNodeRecord.md
@@ -1,0 +1,134 @@
+# Class OpenXRNodeRecord
+
+Provides the description for an OpenXR CameraRig node element.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [HasPassThroughCamera]
+  * [NodeType]
+  * [PassthroughManager]
+  * [Priority]
+  * [XRNodeType]
+* [Methods]
+  * [DisablePassThrough()]
+  * [EnablePassThrough()]
+  * [SetNodeType(Int32)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* OpenXRNodeRecord
+
+##### Namespace
+
+* [Tilia.CameraRigs.OpenXR]
+
+##### Syntax
+
+```
+public class OpenXRNodeRecord : BaseDeviceDetailsRecord
+```
+
+### Properties
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
+```
+
+#### NodeType
+
+The Node Type for the record.
+
+##### Declaration
+
+```
+public XRNode NodeType { get; set; }
+```
+
+#### PassthroughManager
+
+The [PassthroughManager] for handling the camera passthrough.
+
+##### Declaration
+
+```
+public BasePassthroughManager PassthroughManager { get; set; }
+```
+
+#### Priority
+
+##### Declaration
+
+```
+public override int Priority { get; protected set; }
+```
+
+#### XRNodeType
+
+##### Declaration
+
+```
+public override XRNode XRNodeType { get; protected set; }
+```
+
+### Methods
+
+#### DisablePassThrough()
+
+##### Declaration
+
+```
+protected override void DisablePassThrough()
+```
+
+#### EnablePassThrough()
+
+##### Declaration
+
+```
+protected override void EnablePassThrough()
+```
+
+#### SetNodeType(Int32)
+
+Sets the [NodeType].
+
+##### Declaration
+
+```
+public virtual void SetNodeType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the XRNode. |
+
+[Tilia.CameraRigs.OpenXR]: README.md
+[PassthroughManager]: OpenXRNodeRecord.md#PassthroughManager
+[BasePassthroughManager]: BasePassthroughManager.md
+[NodeType]: OpenXRNodeRecord.md#NodeType
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[HasPassThroughCamera]: #HasPassThroughCamera
+[NodeType]: #NodeType
+[PassthroughManager]: #PassthroughManager
+[Priority]: #Priority
+[XRNodeType]: #XRNodeType
+[Methods]: #Methods
+[DisablePassThrough()]: #DisablePassThrough
+[EnablePassThrough()]: #EnablePassThrough
+[SetNodeType(Int32)]: #SetNodeTypeInt32

--- a/Documentation/API/OpenXRNodeRecord.md.meta
+++ b/Documentation/API/OpenXRNodeRecord.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7554f86dedc9dc439a14a37f71848cd
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/PassthroughManager.md
+++ b/Documentation/API/PassthroughManager.md
@@ -1,0 +1,210 @@
+# Class PassthroughManager
+
+Manages the state of camera passthrough on the device.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [CameraManager]
+  * [PassthroughManagers]
+  * [ProcessCameraManager]
+  * [TargetCamera]
+* [Methods]
+  * [ActivatePassthrough()]
+  * [ApplyCameraSettings()]
+  * [Awake()]
+  * [CacheCameraSettings()]
+  * [DeactivatePassthrough()]
+  * [OnDisable()]
+  * [RestoreCachedCameraSettings()]
+  * [StopRestoreCacheRoutine()]
+  * [ToggleARFoundationPassthrough(Boolean)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* [BasePassthroughManager]
+* PassthroughManager
+
+##### Namespace
+
+* [Tilia.CameraRigs.OpenXR]
+
+##### Syntax
+
+```
+public class PassthroughManager : BasePassthroughManager
+```
+
+### Properties
+
+#### CameraManager
+
+The ARCameraManager that controls passthrough via AR Foundation.
+
+##### Declaration
+
+```
+public ARCameraManager CameraManager { get; set; }
+```
+
+#### PassthroughManagers
+
+A [PassthroughManager] collection to process the passthrough logic on.
+
+##### Declaration
+
+```
+public BasePassthroughManager[] PassthroughManagers { get; set; }
+```
+
+#### ProcessCameraManager
+
+Whether to apply the [CameraManager] passthrough process.
+
+##### Declaration
+
+```
+public bool ProcessCameraManager { get; set; }
+```
+
+#### TargetCamera
+
+The target camera to apply passthrough logic to.
+
+##### Declaration
+
+```
+public Camera TargetCamera { get; set; }
+```
+
+### Methods
+
+#### ActivatePassthrough()
+
+Activates the passthrough mode if available.
+
+##### Declaration
+
+```
+public override void ActivatePassthrough()
+```
+
+##### Overrides
+
+[BasePassthroughManager.ActivatePassthrough()]
+
+#### ApplyCameraSettings()
+
+##### Declaration
+
+```
+protected virtual void ApplyCameraSettings()
+```
+
+#### Awake()
+
+##### Declaration
+
+```
+protected virtual void Awake()
+```
+
+#### CacheCameraSettings()
+
+Caches the existing [TargetCamera] settings.
+
+##### Declaration
+
+```
+public virtual void CacheCameraSettings()
+```
+
+#### DeactivatePassthrough()
+
+Deactivates the passthrough mode if available.
+
+##### Declaration
+
+```
+public override void DeactivatePassthrough()
+```
+
+##### Overrides
+
+[BasePassthroughManager.DeactivatePassthrough()]
+
+#### OnDisable()
+
+##### Declaration
+
+```
+protected virtual void OnDisable()
+```
+
+#### RestoreCachedCameraSettings()
+
+##### Declaration
+
+```
+protected virtual IEnumerator RestoreCachedCameraSettings()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Collections.IEnumerator | n/a |
+
+#### StopRestoreCacheRoutine()
+
+##### Declaration
+
+```
+protected virtual void StopRestoreCacheRoutine()
+```
+
+#### ToggleARFoundationPassthrough(Boolean)
+
+##### Declaration
+
+```
+protected virtual void ToggleARFoundationPassthrough(bool state)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | state | n/a |
+
+[Tilia.CameraRigs.OpenXR]: README.md
+[PassthroughManager]: PassthroughManager.md
+[BasePassthroughManager]: BasePassthroughManager.md
+[CameraManager]: PassthroughManager.md#CameraManager
+[BasePassthroughManager.ActivatePassthrough()]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_ActivatePassthrough
+[TargetCamera]: PassthroughManager.md#TargetCamera
+[BasePassthroughManager.DeactivatePassthrough()]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_DeactivatePassthrough
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[CameraManager]: #CameraManager
+[PassthroughManagers]: #PassthroughManagers
+[ProcessCameraManager]: #ProcessCameraManager
+[TargetCamera]: #TargetCamera
+[Methods]: #Methods
+[ActivatePassthrough()]: #ActivatePassthrough
+[ApplyCameraSettings()]: #ApplyCameraSettings
+[Awake()]: #Awake
+[CacheCameraSettings()]: #CacheCameraSettings
+[DeactivatePassthrough()]: #DeactivatePassthrough
+[OnDisable()]: #OnDisable
+[RestoreCachedCameraSettings()]: #RestoreCachedCameraSettings
+[StopRestoreCacheRoutine()]: #StopRestoreCacheRoutine
+[ToggleARFoundationPassthrough(Boolean)]: #ToggleARFoundationPassthroughBoolean

--- a/Documentation/API/PassthroughManager.md.meta
+++ b/Documentation/API/PassthroughManager.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 94e97ad03c901204191de2fde928ef6a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/PassthroughProcessor.md
+++ b/Documentation/API/PassthroughProcessor.md
@@ -1,0 +1,140 @@
+# Class PassthroughProcessor
+
+A base class to provide custom processors for vendor OpenXR extensions.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [SourceManager]
+* [Methods]
+  * [ActivatePassthrough()]
+  * [ActivatePassthroughLogic()]
+  * [DeactivatePassthrough()]
+  * [DeactivatePassthroughLogic()]
+  * [IsValid()]
+  * [SetSourceManagerState(Boolean)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* [BasePassthroughManager]
+* PassthroughProcessor
+
+##### Namespace
+
+* [Tilia.CameraRigs.OpenXR]
+
+##### Syntax
+
+```
+public abstract class PassthroughProcessor : BasePassthroughManager
+```
+
+### Properties
+
+#### SourceManager
+
+The source [PassthroughManager] that is controlling this processor.
+
+##### Declaration
+
+```
+public PassthroughManager SourceManager { get; set; }
+```
+
+### Methods
+
+#### ActivatePassthrough()
+
+Activates the passthrough mode if available.
+
+##### Declaration
+
+```
+public override void ActivatePassthrough()
+```
+
+##### Overrides
+
+[BasePassthroughManager.ActivatePassthrough()]
+
+#### ActivatePassthroughLogic()
+
+##### Declaration
+
+```
+protected abstract void ActivatePassthroughLogic()
+```
+
+#### DeactivatePassthrough()
+
+Deactivates the passthrough mode if available.
+
+##### Declaration
+
+```
+public override void DeactivatePassthrough()
+```
+
+##### Overrides
+
+[BasePassthroughManager.DeactivatePassthrough()]
+
+#### DeactivatePassthroughLogic()
+
+##### Declaration
+
+```
+protected abstract void DeactivatePassthroughLogic()
+```
+
+#### IsValid()
+
+##### Declaration
+
+```
+protected abstract bool IsValid()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### SetSourceManagerState(Boolean)
+
+##### Declaration
+
+```
+protected virtual void SetSourceManagerState(bool state)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | state | n/a |
+
+[BasePassthroughManager]: BasePassthroughManager.md
+[Tilia.CameraRigs.OpenXR]: README.md
+[PassthroughManager]: PassthroughManager.md
+[BasePassthroughManager.ActivatePassthrough()]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_ActivatePassthrough
+[BasePassthroughManager.DeactivatePassthrough()]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_DeactivatePassthrough
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[SourceManager]: #SourceManager
+[Methods]: #Methods
+[ActivatePassthrough()]: #ActivatePassthrough
+[ActivatePassthroughLogic()]: #ActivatePassthroughLogic
+[DeactivatePassthrough()]: #DeactivatePassthrough
+[DeactivatePassthroughLogic()]: #DeactivatePassthroughLogic
+[IsValid()]: #IsValid
+[SetSourceManagerState(Boolean)]: #SetSourceManagerStateBoolean

--- a/Documentation/API/PassthroughProcessor.md.meta
+++ b/Documentation/API/PassthroughProcessor.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f6ff678dfd7b01439a2d9adacce8e15
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -1,0 +1,24 @@
+# Namespace Tilia.CameraRigs.OpenXR
+
+### Classes
+
+#### [BasePassthroughManager]
+
+The base class for a Passthrough Manager
+
+#### [OpenXRNodeRecord]
+
+Provides the description for an OpenXR CameraRig node element.
+
+#### [PassthroughManager]
+
+Manages the state of camera passthrough on the device.
+
+#### [PassthroughProcessor]
+
+A base class to provide custom processors for vendor OpenXR extensions.
+
+[BasePassthroughManager]: BasePassthroughManager.md
+[OpenXRNodeRecord]: OpenXRNodeRecord.md
+[PassthroughManager]: PassthroughManager.md
+[PassthroughProcessor]: PassthroughProcessor.md

--- a/Documentation/API/README.md.meta
+++ b/Documentation/API/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da32443d9044f9d429fc29158c872677
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides.meta
+++ b/Documentation/HowToGuides.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc221b0c8ff1d7647b100265804d330d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides/Installation.meta
+++ b/Documentation/HowToGuides/Installation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3985817f5ec89445801e2e7e1b45677
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -2,18 +2,72 @@
 
 > * Level: Beginner
 >
-> * Reading Time: {x} minutes
+> * Reading Time: 2 minutes
 >
-> * Checked with: {platform and version}
+> * Checked with: Unity 2022.3.62f1
 
 ## Introduction
 
-{Description of how the package is digested into the supported platform.}
+The `CameraRigs.OpenXR` prefab provides a spatial camera rig and controller setup utilizing the OpenXR Framework provided by the Unity software. This prefab can be included in a [Unity] software project via the [Unity Package Manager].
 
 ## Let's Start
 
-### Step X
+### Step 1: Creating a Unity project
 
-{Describe each step with any useful imagery.}
+> You may skip this step if you already have a Unity project to import the package into.
+
+* Create a new project in the Unity software version `2022.3.62f1` (or above) using `3D Template` or open an existing project.
+
+### Step 2: Configuring the Unity project
+
+* Configure the project for XR:
+  * In the Unity software select `Main Menu -> Edit -> Project Settings` to open the `Project Settings` inspector.
+  * Select `XR Plug-in Management`. Click `Install XR Plug-in Management` if the package hasn’t been installed already. You can also install it from the Package Manager window.
+  * After installation completes, select a Plug-in Provider to enable it for the corresponding build target. To do this:
+    * Select a build target (for example, Android).
+    * Select the checkbox to the left of each plug-in you want to use for that build target.
+  * After a plug-in loads, it displays in the left-hand navigation, under XR Plug-in Management. Click the plug-in to configure its settings for each build target.
+
+> The `Configure the project for XR` steps are adapted from the official Unity [Configuring your Unity Project for XR] guide.
+
+### Step 3: Adding the package to the Unity project manifest
+
+* Navigate to the `Packages` directory of your project.
+* Adjust the [project manifest file][Project-Manifest] `manifest.json` in a text editor.
+  * Ensure `https://registry.npmjs.org/` is part of `scopedRegistries`.
+    * Ensure `io.extendreality` is part of `scopes`.
+  * Add `io.extendreality.tilia.camerarigs.openxr.unity` to `dependencies`, stating the latest version.
+
+  A minimal example ends up looking like this. Please note that the version `X.Y.Z` stated here is to be replaced with [the latest released version][Latest-Release] which is currently [![Release][Version-Release]][Releases].
+  ```json
+  {
+    "scopedRegistries": [
+      {
+        "name": "npmjs",
+        "url": "https://registry.npmjs.org/",
+        "scopes": [
+          "io.extendreality"
+        ]
+      }
+    ],
+    "dependencies": {
+      "io.extendreality.tilia.camerarigs.openxr.unity": "X.Y.Z",
+      ...
+    }
+  }
+  ```
+* Switch back to the Unity software and wait for it to finish importing the added package.
 
 ### Done
+
+The `Tilia CameraRigs OpenXR Unity` package will now be available in your Unity project `Packages` directory ready for use in your project.
+
+The package will now also show up in the Unity Package Manager UI. From then on the package can be updated by selecting the package in the Unity Package Manager and clicking on the `Update` button or using the version selection UI.
+
+[Unity]: https://unity3d.com/
+[Unity Package Manager]: https://docs.unity3d.com/Manual/upm-ui.html
+[Project-Manifest]: https://docs.unity3d.com/Manual/upm-manifestPrj.html
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity.svg
+[Releases]: ../../../../../releases
+[Latest-Release]: ../../../../../releases/latest
+[Configuring your Unity Project for XR]: https://docs.unity3d.com/2019.3/Documentation/Manual/configuring-project-for-xr.html

--- a/Documentation/HowToGuides/Installation/README.md.meta
+++ b/Documentation/HowToGuides/Installation/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ee3034b4894cdc4ab87004c9a548d1b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1f615f295473624faca1d02df5ff380
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Config.meta
+++ b/Editor/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e106de39b117ec945a3d4cca5aea663f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Config/OpenXRProfileConfig.cs
+++ b/Editor/Config/OpenXRProfileConfig.cs
@@ -1,0 +1,12 @@
+namespace Tilia.CameraRigs.OpenXR.Config
+{
+    using System.Collections.Generic;
+    using UnityEngine;
+
+    public class OpenXRProfileConfig : ScriptableObject
+    {
+        public string vendorGroup;
+        public List<string> interactionProfiles = new List<string>();
+        public List<string> enabledFeatures = new List<string>();
+    }
+}

--- a/Editor/Config/OpenXRProfileConfig.cs.meta
+++ b/Editor/Config/OpenXRProfileConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ff2fea5ef9e79c469cd177146ab984b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Config/OpenXRProfileManager.cs
+++ b/Editor/Config/OpenXRProfileManager.cs
@@ -1,0 +1,325 @@
+﻿namespace Tilia.CameraRigs.OpenXR.Config
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using UnityEditor;
+    using UnityEditorInternal;
+    using UnityEngine;
+    using UnityEngine.XR.OpenXR;
+    using UnityEngine.XR.OpenXR.Features;
+
+    public abstract class OpenXRProfileManager<ConfigType> : EditorWindow where ConfigType : OpenXRProfileConfig
+    {
+        protected const string menuRoot = "Window/Tilia/OpenXR Profiles/";
+        protected const string menuConfigurePrefix = "Configure/Configure ";
+        protected const string menuConfigureSuffix = " OpenXR Profile";
+        protected const string menuSwitchPrefix = "Switch/Switch To ";
+        protected const string menuSwitchSuffix = " OpenXR Profile";
+
+        protected ConfigType config;
+        protected Vector2 scroll;
+        protected ReorderableList reorderableList;
+
+        public static void OpenWindow<TWindow>() where TWindow : OpenXRProfileManager<ConfigType>
+        {
+            TWindow window = GetWindow<TWindow>();
+            window.titleContent = new GUIContent(typeof(TWindow).Name.Replace("EditorWindow", ""));
+            window.Show();
+        }
+
+        public static void SwitchProfile<ProfileType>(string assetPath) where ProfileType : OpenXRProfileConfig
+        {
+            ProfileType profile = AssetDatabase.LoadAssetAtPath<ProfileType>(assetPath);
+            if (profile == null)
+            {
+                Debug.LogError($"Profile asset not found at: {assetPath}");
+                return;
+            }
+
+            OpenXRSettings openXRSettings = OpenXRSettings.ActiveBuildTargetInstance;
+            if (openXRSettings == null)
+            {
+                Debug.LogError("OpenXR Settings not found");
+                return;
+            }
+
+            foreach (OpenXRFeature feature in openXRSettings.GetFeatures<OpenXRFeature>())
+            {
+                if (feature.enabled)
+                {
+                    feature.enabled = false;
+                }
+            }
+
+            foreach (string interProfileName in profile.interactionProfiles)
+            {
+                foreach (OpenXRFeature feature in openXRSettings.GetFeatures<OpenXRFeature>())
+                {
+                    if (feature.GetType().Name == interProfileName)
+                    {
+                        feature.enabled = true;
+                        break;
+                    }
+                }
+            }
+
+            foreach (string featureName in profile.enabledFeatures)
+            {
+                SetOpenXRFeature(featureName, true);
+            }
+
+            Debug.Log($"Switched to OpenXR Profile {assetPath}");
+        }
+
+        public static void SetOpenXRFeature(string featureName, bool enabled)
+        {
+            OpenXRSettings openXRSettings = OpenXRSettings.ActiveBuildTargetInstance;
+            if (openXRSettings == null)
+            {
+                Debug.LogError("OpenXR settings not found");
+                return;
+            }
+
+            OpenXRFeature[] allFeatures = openXRSettings.GetFeatures<OpenXRFeature>();
+            OpenXRFeature feature = allFeatures.FirstOrDefault(f => f.GetType().Name == featureName);
+            if (feature != null)
+            {
+                feature.enabled = enabled;
+
+                if (Application.isPlaying)
+                {
+                    Debug.LogWarning("Runtime feature changes may not take effect until XR subsystem restart or app restart");
+                }
+            }
+            else
+            {
+                Debug.LogError($"OpenXR feature '{featureName}' not found");
+                Debug.Log("Available features:");
+                foreach (OpenXRFeature f in allFeatures)
+                {
+                    Debug.Log($"  - {f.GetType().Name}");
+                }
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            LoadOrCreateConfig();
+            SetupReorderableList();
+        }
+
+        protected abstract string GetVendorName();
+        protected abstract string GetAssetPath();
+
+        protected virtual void LoadOrCreateConfig()
+        {
+            string path = GetAssetPath();
+            CreatePathIfNotExists(System.IO.Path.GetDirectoryName(path));
+            config = AssetDatabase.LoadAssetAtPath<ConfigType>(path);
+            if (config == null)
+            {
+                config = CreateInstance<ConfigType>();
+                config.vendorGroup = GetVendorName();
+                AssetDatabase.CreateAsset(config, path);
+                AssetDatabase.SaveAssets();
+            }
+        }
+
+        protected virtual void CreatePathIfNotExists(string folderPath)
+        {
+            folderPath = folderPath.Replace("\\", "/").TrimEnd('/');
+            if (folderPath == "Assets" || string.IsNullOrEmpty(folderPath)) return;
+            if (AssetDatabase.IsValidFolder(folderPath)) return;
+
+            string parentFolder = System.IO.Path.GetDirectoryName(folderPath).Replace("\\", "/");
+            CreatePathIfNotExists(parentFolder);
+            string newFolderName = System.IO.Path.GetFileName(folderPath);
+            AssetDatabase.CreateFolder(parentFolder, newFolderName);
+            AssetDatabase.Refresh();
+        }
+
+        protected virtual void SetupReorderableList()
+        {
+            if (config == null) return;
+
+            reorderableList = new ReorderableList(config.interactionProfiles, typeof(string), true, true, true, true);
+
+            reorderableList.drawHeaderCallback = rect =>
+            {
+                EditorGUI.LabelField(rect, $"Interaction Profiles ({config.vendorGroup})", EditorStyles.boldLabel);
+            };
+
+            reorderableList.drawElementCallback = (rect, index, isActive, isFocused) =>
+            {
+                if (index < config.interactionProfiles.Count)
+                {
+                    config.interactionProfiles[index] = EditorGUI.TextField(rect, config.interactionProfiles[index]);
+                }
+            };
+
+            reorderableList.onAddDropdownCallback = (Rect buttonRect, ReorderableList list) =>
+            {
+                GenericMenu menu = new GenericMenu();
+                string[] availableProfiles = GetAvailableInteractionProfileNames();
+
+                string[] notYetAdded = availableProfiles
+                    .Where(name => !config.interactionProfiles.Contains(name))
+                    .ToArray();
+
+                if (notYetAdded.Length > 0)
+                {
+                    foreach (string profileName in notYetAdded)
+                    {
+                        menu.AddItem(new GUIContent(profileName), false, () =>
+                        {
+                            config.interactionProfiles.Add(profileName);
+                            SaveAssets();
+
+                        });
+                    }
+                }
+                else
+                {
+                    menu.AddDisabledItem(new GUIContent("All profiles added"));
+                }
+                menu.DropDown(buttonRect);
+            };
+
+            reorderableList.onRemoveCallback = list =>
+            {
+                if (list.index >= 0 && list.index < config.interactionProfiles.Count)
+                {
+                    config.interactionProfiles.RemoveAt(list.index);
+                    SaveAssets();
+                }
+            };
+        }
+
+        protected virtual void SaveAssets()
+        {
+            EditorUtility.SetDirty(config);
+            AssetDatabase.SaveAssets();
+        }
+
+        protected virtual void OnGUI()
+        {
+            if (config == null)
+            {
+                EditorGUILayout.HelpBox("Configuration not loaded.", MessageType.Error);
+                return;
+            }
+            EditorGUILayout.Space();
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Apply Profile"))
+            {
+                SaveAssets();
+                SwitchProfile<ConfigType>(GetAssetPath());
+            }
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.Space();
+
+            scroll = EditorGUILayout.BeginScrollView(scroll);
+
+            if (reorderableList != null)
+            {
+                reorderableList.DoLayoutList();
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField($"OpenXR Features ({config.vendorGroup})", EditorStyles.boldLabel);
+
+            OpenXRSettings openXRSettings = OpenXRSettings.ActiveBuildTargetInstance;
+            if (openXRSettings != null)
+            {
+                IEnumerable<OpenXRFeature> allFeatures = openXRSettings.GetFeatures<OpenXRFeature>();
+                HashSet<System.Type> interactionFeatureTypes = new HashSet<System.Type>();
+                foreach (OpenXRFeature feature in openXRSettings.GetFeatures<OpenXRInteractionFeature>())
+                {
+                    interactionFeatureTypes.Add(feature.GetType());
+                }
+
+                IEnumerable<OpenXRFeature> nonInteractionFeatures = allFeatures
+                    .Where(feature => !interactionFeatureTypes.Contains(feature.GetType()))
+                    .OrderBy(feature => GetFeatureDisplayName(feature));
+
+                if (config.enabledFeatures == null) config.enabledFeatures = new List<string>();
+
+                foreach (OpenXRFeature feature in nonInteractionFeatures)
+                {
+                    string featureName = feature.GetType().Name;
+                    bool currentlyEnabled = config.enabledFeatures.Contains(featureName);
+
+                    EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+                    EditorGUILayout.BeginHorizontal();
+                    bool newValue = GUILayout.Toggle(currentlyEnabled, GUIContent.none, GUILayout.Width(20));
+                    GUILayout.Space(4);
+                    GUIStyle labelStyle = new GUIStyle(EditorStyles.label);
+                    labelStyle.wordWrap = true;
+                    EditorGUILayout.LabelField(new GUIContent(GetFeatureDisplayName(feature), featureName), labelStyle, GUILayout.ExpandWidth(true));
+                    EditorGUILayout.EndHorizontal();
+                    EditorGUILayout.EndVertical();
+
+                    if (newValue != currentlyEnabled)
+                    {
+                        if (newValue)
+                        {
+                            if (!config.enabledFeatures.Contains(featureName)) config.enabledFeatures.Add(featureName);
+                        }
+                        else
+                        {
+                            config.enabledFeatures.Remove(featureName);
+                        }
+                        SaveAssets();
+                    }
+                }
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("OpenXR Settings not available.", MessageType.Warning);
+            }
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        protected virtual string GetFeatureDisplayName(OpenXRFeature feature)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            System.Type currentType = feature.GetType();
+
+            while (currentType != null)
+            {
+                FieldInfo field = currentType.GetField("nameUi", flags);
+                if (field != null && field.FieldType == typeof(string))
+                {
+                    string value = field.GetValue(feature) as string;
+                    if (!string.IsNullOrEmpty(value))
+                        return value;
+                }
+
+                currentType = currentType.BaseType;
+            }
+
+            return ObjectNames.NicifyVariableName(feature.GetType().Name);
+        }
+
+        protected virtual string[] GetAvailableInteractionProfileNames()
+        {
+            OpenXRSettings openXRSettings = OpenXRSettings.ActiveBuildTargetInstance;
+            if (openXRSettings == null) return new string[0];
+
+            List<string> profileNames = new List<string>();
+            foreach (OpenXRFeature feature in openXRSettings.GetFeatures<OpenXRInteractionFeature>())
+            {
+                string profileName = feature.GetType().Name;
+                if (!string.IsNullOrEmpty(profileName) && !profileNames.Contains(profileName))
+                {
+                    profileNames.Add(profileName);
+                }
+            }
+            return profileNames.OrderBy(name => name).ToArray();
+        }
+    }
+}

--- a/Editor/Config/OpenXRProfileManager.cs.meta
+++ b/Editor/Config/OpenXRProfileManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c66c4493c9f7e24c8e1a5cd5fb0261d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tilia.CameraRigs.OpenXR.Unity.Editor.asmdef
+++ b/Editor/Tilia.CameraRigs.OpenXR.Unity.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Tilia.CameraRigs.XRFramework.Unity.Editor",
+    "rootNamespace": "",
+    "references": [
+        "Zinnia.Editor",
+        "Unity.XR.OpenXR"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/Tilia.CameraRigs.OpenXR.Unity.Editor.asmdef.meta
+++ b/Editor/Tilia.CameraRigs.OpenXR.Unity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 694afae57d8895748b10c4d2547d11ae
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility.meta
+++ b/Editor/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf64bd8520df485479b43adeb3cab378
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility/PrefabCreator.cs
+++ b/Editor/Utility/PrefabCreator.cs
@@ -1,0 +1,28 @@
+namespace Tilia.CameraRigs.OpenXR.Utility
+{
+    using System.IO;
+    using UnityEditor;
+    using Zinnia.Utility;
+
+    public class PrefabCreator : BasePrefabCreator
+    {
+        private const string group = "Tilia/";
+        private const string project = "CameraRigs/";
+        private const string menuItemRoot = topLevelMenuLocation + group + subLevelMenuLocation + project;
+
+        private const string package = "io.extendreality.tilia.camerarigs.openxr.unity";
+        private const string baseDirectory = "Runtime";
+        private const string prefabDirectory = "Prefabs";
+        private const string prefabSuffix = ".prefab";
+
+        private const string prefabCameraRigsUnityXRPluginFramework = "CameraRigs.OpenXR";
+
+        [MenuItem(menuItemRoot + prefabCameraRigsUnityXRPluginFramework, false, priority)]
+        private static void AddCameraRigsTrackedAlias()
+        {
+            string prefab = prefabCameraRigsUnityXRPluginFramework + prefabSuffix;
+            string packageLocation = Path.Combine(packageRoot, package, baseDirectory, prefabDirectory, prefab);
+            CreatePrefab(packageLocation);
+        }
+    }
+}

--- a/Editor/Utility/PrefabCreator.cs.meta
+++ b/Editor/Utility/PrefabCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27b02609510a87c4f8771b64612fbfc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2423761ce2af3b045b91d4cdef010cc5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tilia logo][Tilia-Image]](#)
 
-> ### Tilia {scope} {feature} {platform?}
-> {Description of feature}.
+> ### CameraRigs -> OpenXR
+> A camera rig prefab utilizing the OpenXR Framework for the Unity software.
 
 [![Release][Version-Release]][Releases]
 [![License][License-Badge]][License]
@@ -9,9 +9,9 @@
 
 ## Introduction
 
-{Introduction into the purpose of the feature.}
+The OpenXR camera rig prefab provides a basis for a spatial camera rig that tracks a HMD and up to two controllers (left/right) utilizing the [OpenXR Framework] within the [Unity] software.
 
-> **Requires** {platform and minimum version number}.
+> **Requires** the Unity software version `2022.3.62f1` (or above).
 
 ## Getting Started
 
@@ -35,9 +35,9 @@ Please refer to the Extend Reality [Code of Conduct].
 
 Code released under the [MIT License][License].
 
-[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.svg
-[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.svg
-[project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/{project_type}
+[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity.svg
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity.svg
+[project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/UNITY3D.md
 
 [Tilia-Image]: https://raw.githubusercontent.com/ExtendRealityLtd/related-media/main/github/readme/tilia.png
 [License]: LICENSE.md
@@ -49,3 +49,6 @@ Code released under the [MIT License][License].
 [Releases]: ../../releases
 [Contributing guidelines]: https://github.com/ExtendRealityLtd/.github/blob/master/CONTRIBUTING.md
 [Code of Conduct]: https://github.com/ExtendRealityLtd/.github/blob/master/CODE_OF_CONDUCT.md
+
+[Unity]: https://unity3d.com/
+[OpenXR Framework]: https://docs.unity3d.com/Packages/com.unity.xr.openxr@1.13/manual/index.html

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f1441c0452ecd542ae4a75423eb7af2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47458382a4bf41340a0333ca842014c0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs.meta
+++ b/Runtime/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55e52051586959147b535e2902a6b870
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/CameraRigs.OpenXR.prefab
+++ b/Runtime/Prefabs/CameraRigs.OpenXR.prefab
@@ -1,0 +1,2541 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &270323939077815358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5767290781303468398}
+  - component: {fileID: 4551825595299146516}
+  m_Layer: 0
+  m_Name: RightHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5767290781303468398
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270323939077815358}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3636969768476577644}
+  m_Father: {fileID: 8381626201316927683}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4551825595299146516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270323939077815358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 5
+  duration: 0.005
+--- !u!1 &501172578582848170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8386843243689859043}
+  - component: {fileID: 431479390920754079}
+  - component: {fileID: 1972639219198877611}
+  m_Layer: 0
+  m_Name: LongStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8386843243689859043
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 501172578582848170}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &431479390920754079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 501172578582848170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 1972639219198877611}
+  duration: 0.25
+  interval: 0.005
+--- !u!114 &1972639219198877611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 501172578582848170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 4
+  duration: 0.005
+--- !u!1 &961927562884428063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1451436457020980614}
+  - component: {fileID: 8661495485696599952}
+  m_Layer: 0
+  m_Name: RightHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1451436457020980614
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961927562884428063}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7588694026444334080}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8661495485696599952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961927562884428063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f27fc0668d79644c93af545a243c86a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 7953822028573554274}
+  relativeTo: {fileID: 3425589306487620505}
+  isEstimating: 1
+  velocityAverageFrames: 5
+  angularVelocityAverageFrames: 10
+--- !u!1 &1279778396177983614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3947487734000933859}
+  - component: {fileID: 7524686175830978782}
+  - component: {fileID: 7518497098325608172}
+  m_Layer: 0
+  m_Name: LongLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3947487734000933859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1279778396177983614}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7524686175830978782
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1279778396177983614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 7518497098325608172}
+  duration: 0.25
+  interval: 0.005
+--- !u!114 &7518497098325608172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1279778396177983614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  node: 4
+  duration: 0.005
+--- !u!1 &1402111934071539031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8574319798914919258}
+  - component: {fileID: 1570469750549758777}
+  m_Layer: 0
+  m_Name: ListContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8574319798914919258
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1402111934071539031}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8755566522359765723}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1570469750549758777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1402111934071539031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 1815071937205902062}
+  - {fileID: 7419501722163638439}
+  - {fileID: 1526215602134546977}
+  - {fileID: 7865251902701735970}
+--- !u!1 &1969692545060588945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7610879206465189776}
+  - component: {fileID: 6639520808405954607}
+  m_Layer: 0
+  m_Name: LeftHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7610879206465189776
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969692545060588945}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5058067069086012754}
+  m_Father: {fileID: 8381626201316927683}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6639520808405954607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969692545060588945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 4
+  duration: 0.005
+--- !u!1 &2549313580185905969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6567599773103819355}
+  - component: {fileID: 5356976510353437016}
+  - component: {fileID: 903674316207170584}
+  m_Layer: 0
+  m_Name: ContinuousMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6567599773103819355
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2549313580185905969}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5356976510353437016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2549313580185905969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 903674316207170584}
+  duration: Infinity
+  interval: 0.005
+--- !u!114 &903674316207170584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2549313580185905969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  node: 4
+  duration: 0.005
+--- !u!1 &2759557842805207889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1509010003780451918}
+  m_Layer: 0
+  m_Name: Camera Offset
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1509010003780451918
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2759557842805207889}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3908322436372368395}
+  m_Father: {fileID: 7455428504947032323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3207586688433734083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5090274327978565509}
+  - component: {fileID: 1862567173275132760}
+  - component: {fileID: 3013712383872579130}
+  m_Layer: 0
+  m_Name: ContinuousLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5090274327978565509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207586688433734083}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1862567173275132760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207586688433734083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 3013712383872579130}
+  duration: Infinity
+  interval: 0.005
+--- !u!114 &3013712383872579130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3207586688433734083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  node: 5
+  duration: 0.005
+--- !u!1 &3425589306487620505
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7455428504947032323}
+  - component: {fileID: 8889747625056509988}
+  - component: {fileID: 2985909222468300842}
+  - component: {fileID: 2087740038620856229}
+  - component: {fileID: 7865251902701735970}
+  m_Layer: 0
+  m_Name: CameraRigs.OpenXR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7455428504947032323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3425589306487620505}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1509010003780451918}
+  - {fileID: 7874183890360767716}
+  - {fileID: 9153055571359254672}
+  - {fileID: 8381626201316927683}
+  - {fileID: 7588694026444334080}
+  - {fileID: 8755566522359765723}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8889747625056509988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3425589306487620505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2483b9bd782f9449a5972b61b7d51a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_CameraFloorOffsetObject: {fileID: 2759557842805207889}
+  m_RequestedTrackingMode: 2
+  m_TrackingOriginMode: 1
+  m_TrackingSpace: 1
+  m_CameraYOffset: 0
+--- !u!114 &2985909222468300842
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3425589306487620505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34c0cb8bdc24787439e43b7f145ac31c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playArea: {fileID: 3425589306487620505}
+  headset: {fileID: 3908322436372368398}
+  headsetCamera: {fileID: 3908322436372368396}
+  headsetVelocityTracker: {fileID: 6948070296473170765}
+  supplementHeadsetCameras: {fileID: 0}
+  headsetDeviceDetails: {fileID: 6941295451394307198}
+  dominantController: {fileID: 2087740038620856229}
+  leftController: {fileID: 5525933166607360889}
+  leftControllerVelocityTracker: {fileID: 1150069201731568300}
+  leftControllerHapticProcess: {fileID: 6639520808405954607}
+  leftControllerHapticProfiles: {fileID: 2768722352674242674}
+  leftControllerDeviceDetails: {fileID: 6520672536823130172}
+  rightController: {fileID: 7953822028573554274}
+  rightControllerVelocityTracker: {fileID: 8661495485696599952}
+  rightControllerHapticProcess: {fileID: 4551825595299146516}
+  rightControllerHapticProfiles: {fileID: 1924652170381304486}
+  rightControllerDeviceDetails: {fileID: 1013531998453074883}
+--- !u!114 &2087740038620856229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3425589306487620505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7512583a373897b4aa8971c27e3264cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leftController: {fileID: 6520672536823130172}
+  rightController: {fileID: 1013531998453074883}
+  IsChanging:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &7865251902701735970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3425589306487620505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 2087740038620856229}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!1 &3478346947688415937
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7742790970042069201}
+  - component: {fileID: 2863164304038744255}
+  - component: {fileID: 4581255488644464515}
+  m_Layer: 0
+  m_Name: ShortLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7742790970042069201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3478346947688415937}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2863164304038744255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3478346947688415937}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 4581255488644464515}
+  duration: 0.25
+  interval: 0.25
+--- !u!114 &4581255488644464515
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3478346947688415937}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  node: 4
+  duration: 0.005
+--- !u!1 &3908322436372368398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3908322436372368395}
+  - component: {fileID: 7822650767291034633}
+  - component: {fileID: 3908322436372368396}
+  - component: {fileID: 6941295451394307198}
+  - component: {fileID: 3908322436372368397}
+  - component: {fileID: 1815071937205902062}
+  - component: {fileID: 1318252748422672803}
+  - component: {fileID: 1707773967105499439}
+  - component: {fileID: 7398094460511702503}
+  m_Layer: 0
+  m_Name: HeadCamera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3908322436372368395
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1509010003780451918}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7822650767291034633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 175ec8eefb0e646438b7419a1d67381a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetCamera: {fileID: 3908322436372368396}
+  cameraManager: {fileID: 1707773967105499439}
+  processCameraManager: 1
+  passthroughManagers: []
+--- !u!20 &3908322436372368396
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.01
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &6941295451394307198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 587d9bce1e69e2243a6f13f0ab4a4581, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasEnabled:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  nodeType: 3
+  passthroughManager: {fileID: 7822650767291034633}
+--- !u!81 &3908322436372368397
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+--- !u!114 &1815071937205902062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 6941295451394307198}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!114 &1318252748422672803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2fadf230d1919748a9aa21d40f74619, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_IgnoreTrackingState: 0
+  m_PositionInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Position
+      m_Type: 0
+      m_ExpectedControlType: Vector3
+      m_Id: 2878a242-b3bc-45cc-bcba-da53244d75f0
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 148bd7d1-2491-408c-99bb-21d67e1a1892
+        m_Path: <XRHMD>/devicePosition
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Position
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_RotationInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Rotation
+      m_Type: 0
+      m_ExpectedControlType: Quaternion
+      m_Id: 36857b06-562e-4c55-a490-169031da2552
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 8bf77eb8-1518-4564-8c95-08280e52ee2c
+        m_Path: <XRHMD>/deviceRotation
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Rotation
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_TrackingStateInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Tracking State
+      m_Type: 0
+      m_ExpectedControlType: Integer
+      m_Id: 89df32b9-12c7-4cf6-ba6e-8d149346b454
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 1d611188-bac6-49a1-89e0-f21afabad52a
+        m_Path: <XRHMD>/trackingState
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Tracking State
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_PositionAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: ff563ae3-b879-41ac-a8c2-2aefc4126a0a
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+  m_RotationAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 90e2ccf7-48b9-4f80-93f7-5f318e2b3bdb
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+--- !u!114 &1707773967105499439
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4966719baa26e4b0e8231a24d9bd491a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FocusMode: -1
+  m_LightEstimationMode: -1
+  m_AutoFocus: 1
+  m_LightEstimation: 0
+  m_FacingDirection: 1
+  m_RenderMode: 0
+--- !u!114 &7398094460511702503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3908322436372368398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 816b289ef451e094f9ae174fb4cf8db0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UseCustomMaterial: 0
+  m_CustomMaterial: {fileID: 0}
+--- !u!1 &3935137477481793762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8011027913252794334}
+  - component: {fileID: 772155709061513258}
+  - component: {fileID: 3844257191239141350}
+  m_Layer: 0
+  m_Name: LongMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8011027913252794334
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3935137477481793762}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &772155709061513258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3935137477481793762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 3844257191239141350}
+  duration: 0.25
+  interval: 0.005
+--- !u!114 &3844257191239141350
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3935137477481793762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  node: 4
+  duration: 0.005
+--- !u!1 &4251588668937853521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3636969768476577644}
+  - component: {fileID: 1924652170381304486}
+  m_Layer: 0
+  m_Name: RightHapticProfiles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3636969768476577644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4251588668937853521}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5076208640052862118}
+  - {fileID: 2816310900550609470}
+  - {fileID: 7322051445158530625}
+  - {fileID: 7299361061831433738}
+  - {fileID: 4075662669975802449}
+  - {fileID: 336373762287429617}
+  - {fileID: 5090274327978565509}
+  - {fileID: 5547093137268350482}
+  - {fileID: 4680698388817242969}
+  m_Father: {fileID: 5767290781303468398}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1924652170381304486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4251588668937853521}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 1115964845525701435}
+  - {fileID: 8783160177781983088}
+  - {fileID: 4161689748293695809}
+  - {fileID: 8212428235846075348}
+  - {fileID: 2381153724676170026}
+  - {fileID: 7116468518355673953}
+  - {fileID: 1862567173275132760}
+  - {fileID: 8068565056495832746}
+  - {fileID: 5265858379646971114}
+--- !u!1 &4593292806244760535
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8381626201316927683}
+  m_Layer: 0
+  m_Name: HapticPulsers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8381626201316927683
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4593292806244760535}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7610879206465189776}
+  - {fileID: 5767290781303468398}
+  m_Father: {fileID: 7455428504947032323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4635690726023100218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 830852402777493454}
+  - component: {fileID: 1150069201731568300}
+  m_Layer: 0
+  m_Name: LeftHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &830852402777493454
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4635690726023100218}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7588694026444334080}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1150069201731568300
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4635690726023100218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f27fc0668d79644c93af545a243c86a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 5525933166607360889}
+  relativeTo: {fileID: 3425589306487620505}
+  isEstimating: 1
+  velocityAverageFrames: 5
+  angularVelocityAverageFrames: 10
+--- !u!1 &5107581501008203621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4277943026644529427}
+  - component: {fileID: 2313206532510892564}
+  - component: {fileID: 1661719633958514664}
+  m_Layer: 0
+  m_Name: ContinuousStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4277943026644529427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5107581501008203621}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2313206532510892564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5107581501008203621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 1661719633958514664}
+  duration: Infinity
+  interval: 0.005
+--- !u!114 &1661719633958514664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5107581501008203621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 4
+  duration: 0.005
+--- !u!1 &5505527683572617577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5058067069086012754}
+  - component: {fileID: 2768722352674242674}
+  m_Layer: 0
+  m_Name: LeftHapticProfiles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5058067069086012754
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5505527683572617577}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7742790970042069201}
+  - {fileID: 8345804480134013738}
+  - {fileID: 2392958697229753085}
+  - {fileID: 3947487734000933859}
+  - {fileID: 8011027913252794334}
+  - {fileID: 8386843243689859043}
+  - {fileID: 8335781369993038372}
+  - {fileID: 6567599773103819355}
+  - {fileID: 4277943026644529427}
+  m_Father: {fileID: 7610879206465189776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2768722352674242674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5505527683572617577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 2863164304038744255}
+  - {fileID: 6465654543023226749}
+  - {fileID: 3533413279500204468}
+  - {fileID: 7524686175830978782}
+  - {fileID: 772155709061513258}
+  - {fileID: 431479390920754079}
+  - {fileID: 7808286164947810420}
+  - {fileID: 5356976510353437016}
+  - {fileID: 2313206532510892564}
+--- !u!1 &5525933166607360889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7874183890360767716}
+  - component: {fileID: 7419501722163638439}
+  - component: {fileID: 7397684835756130841}
+  - component: {fileID: 6520672536823130172}
+  m_Layer: 0
+  m_Name: LeftHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7874183890360767716
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5525933166607360889}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7455428504947032323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7419501722163638439
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5525933166607360889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 6520672536823130172}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!114 &7397684835756130841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5525933166607360889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2fadf230d1919748a9aa21d40f74619, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_IgnoreTrackingState: 0
+  m_PositionInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Position
+      m_Type: 0
+      m_ExpectedControlType: Vector3
+      m_Id: 989dca53-c1f4-42ed-b737-d735d8391cff
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 148bd7d1-2491-408c-99bb-21d67e1a1892
+        m_Path: <XRController>{LeftHand}/devicePosition
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Position
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_RotationInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Rotation
+      m_Type: 0
+      m_ExpectedControlType: Quaternion
+      m_Id: 725e6e08-08b2-45dd-a07d-53c5d05b42cd
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 8bf77eb8-1518-4564-8c95-08280e52ee2c
+        m_Path: <XRController>{LeftHand}/deviceRotation
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Rotation
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_TrackingStateInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Tracking State
+      m_Type: 0
+      m_ExpectedControlType: Integer
+      m_Id: 1024e45b-3fc5-4382-bc43-4a679989eacf
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 1d611188-bac6-49a1-89e0-f21afabad52a
+        m_Path: <XRController>{LeftHand}/trackingState
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Tracking State
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_PositionAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 934e29ae-ac7a-479f-86a9-4a72121a3341
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+  m_RotationAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 1751c8b7-edc5-4895-998a-acf9e9228da4
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+--- !u!114 &6520672536823130172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5525933166607360889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 587d9bce1e69e2243a6f13f0ab4a4581, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasEnabled:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  nodeType: 4
+  passthroughManager: {fileID: 0}
+--- !u!1 &5743736442787293073
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5547093137268350482}
+  - component: {fileID: 8068565056495832746}
+  - component: {fileID: 7106915760683173874}
+  m_Layer: 0
+  m_Name: ContinuousMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5547093137268350482
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5743736442787293073}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8068565056495832746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5743736442787293073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 7106915760683173874}
+  duration: Infinity
+  interval: 0.005
+--- !u!114 &7106915760683173874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5743736442787293073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  node: 5
+  duration: 0.005
+--- !u!1 &5877439716126637518
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4680698388817242969}
+  - component: {fileID: 5265858379646971114}
+  - component: {fileID: 373949664498205153}
+  m_Layer: 0
+  m_Name: ContinuousStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4680698388817242969
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5877439716126637518}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5265858379646971114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5877439716126637518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 373949664498205153}
+  duration: Infinity
+  interval: 0.005
+--- !u!114 &373949664498205153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5877439716126637518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 5
+  duration: 0.005
+--- !u!1 &6365750613633513545
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4075662669975802449}
+  - component: {fileID: 2381153724676170026}
+  - component: {fileID: 2264554784387441138}
+  m_Layer: 0
+  m_Name: LongMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4075662669975802449
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6365750613633513545}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2381153724676170026
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6365750613633513545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 2264554784387441138}
+  duration: 0.25
+  interval: 0.005
+--- !u!114 &2264554784387441138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6365750613633513545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  node: 5
+  duration: 0.005
+--- !u!1 &6423635684171921465
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5076208640052862118}
+  - component: {fileID: 1115964845525701435}
+  - component: {fileID: 1387776894559132377}
+  m_Layer: 0
+  m_Name: ShortLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5076208640052862118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6423635684171921465}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1115964845525701435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6423635684171921465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 1387776894559132377}
+  duration: 0.25
+  interval: 0.25
+--- !u!114 &1387776894559132377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6423635684171921465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  node: 5
+  duration: 0.005
+--- !u!1 &6556220149695893842
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7299361061831433738}
+  - component: {fileID: 8212428235846075348}
+  - component: {fileID: 2117368333386042735}
+  m_Layer: 0
+  m_Name: LongLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7299361061831433738
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6556220149695893842}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8212428235846075348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6556220149695893842}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 2117368333386042735}
+  duration: 0.25
+  interval: 0.005
+--- !u!114 &2117368333386042735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6556220149695893842}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  node: 5
+  duration: 0.005
+--- !u!1 &6993194934652746550
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2392958697229753085}
+  - component: {fileID: 3533413279500204468}
+  - component: {fileID: 2523217189940918853}
+  m_Layer: 0
+  m_Name: ShortStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2392958697229753085
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6993194934652746550}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3533413279500204468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6993194934652746550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 2523217189940918853}
+  duration: 0.25
+  interval: 0.25
+--- !u!114 &2523217189940918853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6993194934652746550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 4
+  duration: 0.005
+--- !u!1 &7894948685334614533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7322051445158530625}
+  - component: {fileID: 4161689748293695809}
+  - component: {fileID: 4956312976263528442}
+  m_Layer: 0
+  m_Name: ShortStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7322051445158530625
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7894948685334614533}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4161689748293695809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7894948685334614533}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 4956312976263528442}
+  duration: 0.25
+  interval: 0.25
+--- !u!114 &4956312976263528442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7894948685334614533}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 5
+  duration: 0.005
+--- !u!1 &7953822028573554274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9153055571359254672}
+  - component: {fileID: 1526215602134546977}
+  - component: {fileID: 1438102714514417272}
+  - component: {fileID: 1013531998453074883}
+  m_Layer: 0
+  m_Name: RightHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9153055571359254672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7953822028573554274}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7455428504947032323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1526215602134546977
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7953822028573554274}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 1013531998453074883}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!114 &1438102714514417272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7953822028573554274}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2fadf230d1919748a9aa21d40f74619, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_IgnoreTrackingState: 0
+  m_PositionInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Position
+      m_Type: 0
+      m_ExpectedControlType: Vector3
+      m_Id: 9449d45b-2cb3-4236-90ba-e03030285367
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 148bd7d1-2491-408c-99bb-21d67e1a1892
+        m_Path: <XRController>{RightHand}/devicePosition
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Position
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_RotationInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Rotation
+      m_Type: 0
+      m_ExpectedControlType: Quaternion
+      m_Id: 87a1b11b-eed6-4b31-a8ca-08cab0e51b64
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 8bf77eb8-1518-4564-8c95-08280e52ee2c
+        m_Path: <XRController>{RightHand}/deviceRotation
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Rotation
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_TrackingStateInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Tracking State
+      m_Type: 0
+      m_ExpectedControlType: Integer
+      m_Id: 8cd4d475-c3d2-415d-9e79-eb00643ba921
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 1d611188-bac6-49a1-89e0-f21afabad52a
+        m_Path: <XRController>{RightHand}/trackingState
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Tracking State
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_PositionAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 2c32c00a-e909-468d-9ddd-ce213df1c9ae
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+  m_RotationAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: fe7e1696-46d6-4478-8112-e94d83af8a21
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+--- !u!114 &1013531998453074883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7953822028573554274}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 587d9bce1e69e2243a6f13f0ab4a4581, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasEnabled:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  nodeType: 5
+  passthroughManager: {fileID: 0}
+--- !u!1 &7965627931189700128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8345804480134013738}
+  - component: {fileID: 6465654543023226749}
+  - component: {fileID: 323721241079807062}
+  m_Layer: 0
+  m_Name: ShortMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8345804480134013738
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7965627931189700128}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6465654543023226749
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7965627931189700128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 323721241079807062}
+  duration: 0.25
+  interval: 0.25
+--- !u!114 &323721241079807062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7965627931189700128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  node: 4
+  duration: 0.005
+--- !u!1 &8180658904077416238
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2816310900550609470}
+  - component: {fileID: 8783160177781983088}
+  - component: {fileID: 670244512307663896}
+  m_Layer: 0
+  m_Name: ShortMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2816310900550609470
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8180658904077416238}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8783160177781983088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8180658904077416238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 670244512307663896}
+  duration: 0.25
+  interval: 0.25
+--- !u!114 &670244512307663896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8180658904077416238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  node: 5
+  duration: 0.005
+--- !u!1 &8417298503695801701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 336373762287429617}
+  - component: {fileID: 7116468518355673953}
+  - component: {fileID: 8606939700441569278}
+  m_Layer: 0
+  m_Name: LongStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &336373762287429617
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8417298503695801701}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3636969768476577644}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7116468518355673953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8417298503695801701}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 8606939700441569278}
+  duration: 0.25
+  interval: 0.005
+--- !u!114 &8606939700441569278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8417298503695801701}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  node: 5
+  duration: 0.005
+--- !u!1 &8693616291855171140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8335781369993038372}
+  - component: {fileID: 7808286164947810420}
+  - component: {fileID: 1783546450993727258}
+  m_Layer: 0
+  m_Name: ContinuousLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8335781369993038372
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8693616291855171140}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5058067069086012754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7808286164947810420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8693616291855171140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d79347ffad2339489094bc54df156ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hapticProcess: {fileID: 1783546450993727258}
+  duration: Infinity
+  interval: 0.005
+--- !u!114 &1783546450993727258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8693616291855171140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c715c2bacbf81914bbb8517cd2f9d80b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  node: 4
+  duration: 0.005
+--- !u!1 &9044683175550804043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7588694026444334080}
+  m_Layer: 0
+  m_Name: VelocityTrackers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7588694026444334080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9044683175550804043}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4525666966042436125}
+  - {fileID: 830852402777493454}
+  - {fileID: 1451436457020980614}
+  m_Father: {fileID: 7455428504947032323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9135056565189231947
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8755566522359765723}
+  - component: {fileID: 4317557470973403023}
+  m_Layer: 0
+  m_Name: MomentProcessor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8755566522359765723
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9135056565189231947}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8574319798914919258}
+  m_Father: {fileID: 7455428504947032323}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4317557470973403023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9135056565189231947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  processMoment: 5
+  processes: {fileID: 1570469750549758777}
+--- !u!1 &9213639455546335692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4525666966042436125}
+  - component: {fileID: 6948070296473170765}
+  m_Layer: 0
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4525666966042436125
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9213639455546335692}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7588694026444334080}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6948070296473170765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9213639455546335692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f27fc0668d79644c93af545a243c86a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 3908322436372368398}
+  relativeTo: {fileID: 3425589306487620505}
+  isEstimating: 1
+  velocityAverageFrames: 5
+  angularVelocityAverageFrames: 10

--- a/Runtime/Prefabs/CameraRigs.OpenXR.prefab.meta
+++ b/Runtime/Prefabs/CameraRigs.OpenXR.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50b36a177f4e46447a70b5928f9efddc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources.meta
+++ b/Runtime/SharedResources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68f793a533018ea43a1fd30117a45199
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts.meta
+++ b/Runtime/SharedResources/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e405ec45704414b42aabe272a68de914
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/OpenXRNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/OpenXRNodeRecord.cs
@@ -1,0 +1,89 @@
+namespace Tilia.CameraRigs.OpenXR
+{
+    using UnityEngine;
+    using UnityEngine.XR;
+    using Zinnia.Extension;
+    using Zinnia.Tracking.CameraRig;
+
+    /// <summary>
+    /// Provides the description for an OpenXR CameraRig node element.
+    /// </summary>
+    public class OpenXRNodeRecord : BaseDeviceDetailsRecord
+    {
+        [Tooltip("The Node Type for the record.")]
+        [SerializeField]
+        private XRNode nodeType;
+        /// <summary>
+        /// The Node Type for the record.
+        /// </summary>
+        public XRNode NodeType
+        {
+            get
+            {
+                return nodeType;
+            }
+            set
+            {
+                nodeType = value;
+            }
+        }
+
+        [Tooltip("The PassthroughManager for handling the camera passthrough.")]
+        [SerializeField]
+        private BasePassthroughManager passthroughManager;
+        /// <summary>
+        /// The <see cref="PassthroughManager"/> for handling the camera passthrough.
+        /// </summary>
+        public BasePassthroughManager PassthroughManager
+        {
+            get
+            {
+                return passthroughManager;
+            }
+            set
+            {
+                passthroughManager = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override XRNode XRNodeType { get { return NodeType; } protected set { NodeType = value; } }
+        /// <inheritdoc/>
+        public override int Priority { get => 0; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => PassthroughManager != null; protected set => throw new System.NotImplementedException(); }
+
+        /// <inheritdoc/>
+        protected override void EnablePassThrough()
+        {
+            if (!HasPassThroughCamera)
+            {
+                return;
+            }
+
+            PassthroughManager.ActivatePassthrough();
+            base.EnablePassThrough();
+        }
+
+        /// <inheritdoc/>
+        protected override void DisablePassThrough()
+        {
+            if (!HasPassThroughCamera)
+            {
+                return;
+            }
+
+            PassthroughManager.DeactivatePassthrough();
+            base.DisablePassThrough();
+        }
+
+        /// <summary>
+        /// Sets the <see cref="NodeType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="XRNode"/>.</param>
+        public virtual void SetNodeType(int index)
+        {
+            NodeType = EnumExtensions.GetByIndex<XRNode>(index);
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/OpenXRNodeRecord.cs.meta
+++ b/Runtime/SharedResources/Scripts/OpenXRNodeRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 587d9bce1e69e2243a6f13f0ab4a4581
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/PassthroughManager.cs
+++ b/Runtime/SharedResources/Scripts/PassthroughManager.cs
@@ -1,0 +1,153 @@
+namespace Tilia.CameraRigs.OpenXR
+{
+    using System.Collections;
+    using UnityEngine;
+    using UnityEngine.XR.ARFoundation;
+
+    /// <summary>
+    /// The base class for a Passthrough Manager
+    /// </summary>
+    public abstract class BasePassthroughManager : MonoBehaviour
+    {
+        /// <summary>
+        /// Activates the passthrough mode if available.
+        /// </summary>
+        public abstract void ActivatePassthrough();
+        /// <summary>
+        /// Deactivates the passthrough mode if available.
+        /// </summary>
+        public abstract void DeactivatePassthrough();
+    }
+
+    /// <summary>
+    /// Manages the state of camera passthrough on the device.
+    /// </summary>
+    public class PassthroughManager : BasePassthroughManager
+    {
+        [Tooltip("The target camera to apply passthrough logic to.")]
+        [SerializeField]
+        private Camera targetCamera;
+        /// <summary>
+        /// The target camera to apply passthrough logic to.
+        /// </summary>
+        public Camera TargetCamera
+        {
+            get { return targetCamera; }
+            set { targetCamera = value; }
+        }
+
+        [Tooltip("The ARCameraManager that controls passthrough via AR Foundation.")]
+        [SerializeField]
+        private ARCameraManager cameraManager;
+        /// <summary>
+        /// The <see cref="ARCameraManager"/> that controls passthrough via AR Foundation.
+        /// </summary>
+        public ARCameraManager CameraManager
+        {
+            get { return cameraManager; }
+            set { cameraManager = value; }
+        }
+
+        [Tooltip("Whether to apply the CameraManager passthrough process.")]
+        [SerializeField]
+        private bool processCameraManager = true;
+        /// <summary>
+        /// Whether to apply the <see cref="CameraManager"/> passthrough process.
+        /// </summary>
+        public bool ProcessCameraManager
+        {
+            get { return processCameraManager; }
+            set { processCameraManager = value; }
+        }
+
+        [Tooltip("A PassthroughManager collection to process the passthrough logic on.")]
+        [SerializeField]
+        private BasePassthroughManager[] passthroughManagers = new BasePassthroughManager[0];
+        /// <summary>
+        /// A <see cref="PassthroughManager"/> collection to process the passthrough logic on.
+        /// </summary>
+        public BasePassthroughManager[] PassthroughManagers
+        {
+            get { return passthroughManagers; }
+            set { passthroughManagers = value; }
+        }
+
+        private CameraClearFlags cachedClearFlags;
+        private Color cachedCameraBackground;
+        private bool cachedProcessPassthroughState;
+        Coroutine restoreCacheRoutine;
+
+        /// <inheritdoc/>
+        public override void ActivatePassthrough()
+        {
+            StopRestoreCacheRoutine();
+            cachedProcessPassthroughState = ProcessCameraManager;
+            ApplyCameraSettings();
+            foreach (BasePassthroughManager processor in passthroughManagers)
+            {
+                processor.ActivatePassthrough();
+            }
+            ToggleARFoundationPassthrough(true);
+            ProcessCameraManager = cachedProcessPassthroughState;
+        }
+
+        /// <inheritdoc/>
+        public override void DeactivatePassthrough()
+        {
+            if (restoreCacheRoutine != null) return;
+            cachedProcessPassthroughState = ProcessCameraManager;
+            foreach (BasePassthroughManager processor in passthroughManagers)
+            {
+                processor.DeactivatePassthrough();
+            }
+            ToggleARFoundationPassthrough(false);
+            restoreCacheRoutine = StartCoroutine(RestoreCachedCameraSettings());
+            ProcessCameraManager = cachedProcessPassthroughState;
+        }
+
+        /// <summary>
+        /// Caches the existing <see cref="TargetCamera"/> settings.
+        /// </summary>
+        public virtual void CacheCameraSettings()
+        {
+            cachedClearFlags = TargetCamera.clearFlags;
+            cachedCameraBackground = TargetCamera.backgroundColor;
+        }
+
+        protected virtual void Awake()
+        {
+            CacheCameraSettings();
+        }
+
+        protected virtual void OnDisable()
+        {
+            StopRestoreCacheRoutine();
+        }
+
+        protected virtual void StopRestoreCacheRoutine()
+        {
+            if (restoreCacheRoutine == null) return;
+            StopCoroutine(restoreCacheRoutine);
+            restoreCacheRoutine = null;
+        }
+
+        protected virtual void ToggleARFoundationPassthrough(bool state)
+        {
+            if (!ProcessCameraManager) return;
+            CameraManager.enabled = state;
+        }
+
+        protected virtual void ApplyCameraSettings()
+        {
+            TargetCamera.clearFlags = CameraClearFlags.SolidColor;
+            TargetCamera.backgroundColor = new Color(0f, 0f, 0f, 0f);
+        }
+
+        protected virtual IEnumerator RestoreCachedCameraSettings()
+        {
+            yield return new WaitForEndOfFrame();
+            TargetCamera.clearFlags = cachedClearFlags;
+            TargetCamera.backgroundColor = cachedCameraBackground;
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/PassthroughManager.cs.meta
+++ b/Runtime/SharedResources/Scripts/PassthroughManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 175ec8eefb0e646438b7419a1d67381a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/PassthroughProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PassthroughProcessor.cs
@@ -1,0 +1,37 @@
+namespace Tilia.CameraRigs.OpenXR
+{
+    /// <summary>
+    /// A base class to provide custom processors for vendor OpenXR extensions.
+    /// </summary>
+    public abstract class PassthroughProcessor : BasePassthroughManager
+    {
+        /// <summary>
+        /// The source <see cref="PassthroughManager"/> that is controlling this processor.
+        /// </summary>
+        public PassthroughManager SourceManager { get; set; }
+
+        /// <inheritdoc/>
+        public override void ActivatePassthrough()
+        {
+            if (!IsValid()) return;
+            ActivatePassthroughLogic();
+        }
+
+        /// <inheritdoc/>
+        public override void DeactivatePassthrough()
+        {
+            if (!IsValid()) return;
+            DeactivatePassthroughLogic();
+        }
+
+        protected abstract bool IsValid();
+        protected abstract void ActivatePassthroughLogic();
+        protected abstract void DeactivatePassthroughLogic();
+
+        protected virtual void SetSourceManagerState(bool state)
+        {
+            if (SourceManager == null) return;
+            SourceManager.ProcessCameraManager = state;
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/PassthroughProcessor.cs.meta
+++ b/Runtime/SharedResources/Scripts/PassthroughProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fba39e26e951cd844b4329b64d087009
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tilia.CameraRigs.OpenXR.Unity.Runtime.asmdef
+++ b/Runtime/Tilia.CameraRigs.OpenXR.Unity.Runtime.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.CameraRigs.OpenXR.Unity.Runtime",
+    "rootNamespace": "",
+    "references": [
+        "Zinnia.Runtime",
+        "Unity.XR.ARFoundation",
+        "Unity.XR.OpenXR"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/Tilia.CameraRigs.OpenXR.Unity.Runtime.asmdef.meta
+++ b/Runtime/Tilia.CameraRigs.OpenXR.Unity.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fb028fe22e6301f45bc4d74d8a857779
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin.meta
+++ b/Samples~/PICO OpenXR Plugin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71f173eaf0326574595638e983812b08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Editor.meta
+++ b/Samples~/PICO OpenXR Plugin/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad5f31622d1806448bb186ac752e08eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Editor/Config.meta
+++ b/Samples~/PICO OpenXR Plugin/Editor/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29b846c6661eedd469701478f04b908e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Editor/Config/PicoProfileManager.cs
+++ b/Samples~/PICO OpenXR Plugin/Editor/Config/PicoProfileManager.cs
@@ -1,0 +1,26 @@
+namespace Tilia.CameraRigs.OpenXR.PicoOpenXRPlugin.Config
+{
+    using Tilia.CameraRigs.OpenXR.Config;
+    using UnityEditor;
+
+    public class PicoProfileManager : OpenXRProfileManager<OpenXRProfileConfig>
+    {
+        private static readonly string _vendorName = "Pico";
+        private static string _assetPath = "Assets/OpenXRProfiles/PicoProfile.asset";
+
+        [MenuItem(menuRoot + menuConfigurePrefix + "Pico" + menuConfigureSuffix)]
+        public static void ShowWindow()
+        {
+            OpenWindow<PicoProfileManager>();
+        }
+
+        [MenuItem(menuRoot + menuSwitchPrefix + "Pico" + menuSwitchSuffix)]
+        public static void SwitchToMetaProfile()
+        {
+            SwitchProfile<OpenXRProfileConfig>(_assetPath);
+        }
+
+        protected override string GetVendorName() => _vendorName;
+        protected override string GetAssetPath() => _assetPath;
+    }
+}

--- a/Samples~/PICO OpenXR Plugin/Editor/Config/PicoProfileManager.cs.meta
+++ b/Samples~/PICO OpenXR Plugin/Editor/Config/PicoProfileManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e5b7dd8b4259d446b8ee3cadd7ff706
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.Editor.asmdef
+++ b/Samples~/PICO OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:694afae57d8895748b10c4d2547d11ae"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Samples~/PICO OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.Editor.asmdef.meta
+++ b/Samples~/PICO OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4fda93d527ab8b9438c4e941f82719e8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Example.PicoProfile.asset
+++ b/Samples~/PICO OpenXR Plugin/Example.PicoProfile.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ff2fea5ef9e79c469cd177146ab984b, type: 3}
+  m_Name: Example.PicoProfile
+  m_EditorClassIdentifier: 
+  vendorGroup: Pico
+  interactionProfiles:
+  - PICO4ControllerProfile
+  - PICO4UltraControllerProfile
+  - PICOG3ControllerProfile
+  - PICONeo3ControllerProfile
+  enabledFeatures:
+  - PICOFeature
+  - OpenXRExtensions
+  - PassthroughFeature

--- a/Samples~/PICO OpenXR Plugin/Example.PicoProfile.asset.meta
+++ b/Samples~/PICO OpenXR Plugin/Example.PicoProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34977484052d29741a9ecbfc9e0da27e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Runtime.meta
+++ b/Samples~/PICO OpenXR Plugin/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0227691521a51ee4aa49b6e8d2023165
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Runtime/PicoPassthroughProcessor.cs
+++ b/Samples~/PICO OpenXR Plugin/Runtime/PicoPassthroughProcessor.cs
@@ -1,0 +1,25 @@
+namespace Tilia.CameraRigs.OpenXR.PicoOpenXRPlugin
+{
+    using Unity.XR.OpenXR.Features.PICOSupport;
+    using UnityEngine.XR.OpenXR;
+
+    public class PicoPassthroughProcessor : PassthroughProcessor
+    {
+        protected override void ActivatePassthroughLogic()
+        {
+            SetSourceManagerState(false);
+            PassthroughFeature.EnableSeeThroughManual(true);
+        }
+
+        protected override void DeactivatePassthroughLogic()
+        {
+            SetSourceManagerState(false);
+            PassthroughFeature.EnableSeeThroughManual(false);
+        }
+
+        protected override bool IsValid()
+        {
+            return OpenXRRuntime.name.ToLower().Contains("pico");
+        }
+    }
+}

--- a/Samples~/PICO OpenXR Plugin/Runtime/PicoPassthroughProcessor.cs.meta
+++ b/Samples~/PICO OpenXR Plugin/Runtime/PicoPassthroughProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e722f01a5790b02468b9a808b40a4449
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/PICO OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.asmdef
+++ b/Samples~/PICO OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin",
+    "rootNamespace": "",
+    "references": [
+        "GUID:fb028fe22e6301f45bc4d74d8a857779",
+        "GUID:d1451cc2aec4ed743adcac8be3b46381",
+        "GUID:4847341ff46394e83bb78fbd0652937e"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Samples~/PICO OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.asmdef.meta
+++ b/Samples~/PICO OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.PicoOpenXRPlugin.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3d8cd13694f5f744ab06b85bd449384
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Unity OpenXR Meta.meta
+++ b/Samples~/Unity OpenXR Meta.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 746c98ff71deadd4ca91b508609c2b77
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Unity OpenXR Meta/Editor.meta
+++ b/Samples~/Unity OpenXR Meta/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e1221ce8d908564dad31934639a43d0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Unity OpenXR Meta/Editor/Config.meta
+++ b/Samples~/Unity OpenXR Meta/Editor/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf0bea15c93619b4db2bae0742e79ab9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Unity OpenXR Meta/Editor/Config/MetaProfileManager.cs
+++ b/Samples~/Unity OpenXR Meta/Editor/Config/MetaProfileManager.cs
@@ -1,0 +1,26 @@
+namespace Tilia.CameraRigs.OpenXR.MetaOpenXRPlugin.Config
+{
+    using Tilia.CameraRigs.OpenXR.Config;
+    using UnityEditor;
+
+    public class MetaProfileManager : OpenXRProfileManager<OpenXRProfileConfig>
+    {
+        private static readonly string _vendorName = "Meta";
+        private static string _assetPath = "Assets/OpenXRProfiles/MetaProfile.asset";
+
+        [MenuItem(menuRoot + menuConfigurePrefix + "Meta" + menuConfigureSuffix)]
+        public static void ShowWindow()
+        {
+            OpenWindow<MetaProfileManager>();
+        }
+
+        [MenuItem(menuRoot + menuSwitchPrefix + "Meta" + menuSwitchSuffix)]
+        public static void SwitchToMetaProfile()
+        {
+            SwitchProfile<OpenXRProfileConfig>(_assetPath);
+        }
+
+        protected override string GetVendorName() => _vendorName;
+        protected override string GetAssetPath() => _assetPath;
+    }
+}

--- a/Samples~/Unity OpenXR Meta/Editor/Config/MetaProfileManager.cs.meta
+++ b/Samples~/Unity OpenXR Meta/Editor/Config/MetaProfileManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff50c50d619e7bd4c871e01933d37e1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Unity OpenXR Meta/Editor/Tilia.CameraRigs.OpenXR.Unity.OpenXRMeta.Editor.asmdef
+++ b/Samples~/Unity OpenXR Meta/Editor/Tilia.CameraRigs.OpenXR.Unity.OpenXRMeta.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.CameraRigs.OpenXR.Unity.OpenXRMeta.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:694afae57d8895748b10c4d2547d11ae"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Samples~/Unity OpenXR Meta/Editor/Tilia.CameraRigs.OpenXR.Unity.OpenXRMeta.Editor.asmdef.meta
+++ b/Samples~/Unity OpenXR Meta/Editor/Tilia.CameraRigs.OpenXR.Unity.OpenXRMeta.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cf46c5ebe2f546544b906f5b63666c47
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Unity OpenXR Meta/Example.MetaProfile.asset
+++ b/Samples~/Unity OpenXR Meta/Example.MetaProfile.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ff2fea5ef9e79c469cd177146ab984b, type: 3}
+  m_Name: Example.MetaProfile
+  m_EditorClassIdentifier: 
+  vendorGroup: Meta
+  interactionProfiles:
+  - OculusTouchControllerProfile
+  - MetaQuestTouchPlusControllerProfile
+  - MetaQuestTouchProControllerProfile
+  enabledFeatures:
+  - ARSessionFeature
+  - MetaQuestFeature
+  - ARCameraFeature

--- a/Samples~/Unity OpenXR Meta/Example.MetaProfile.asset.meta
+++ b/Samples~/Unity OpenXR Meta/Example.MetaProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f7bd25dff8eb844bb9c06f6e406f7d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin.meta
+++ b/Samples~/VIVE OpenXR Plugin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e245285d92fb2c14cb2afe7cf3519726
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Editor.meta
+++ b/Samples~/VIVE OpenXR Plugin/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c9cc2c49c2761d4c959932d886ee152
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Editor/Config.meta
+++ b/Samples~/VIVE OpenXR Plugin/Editor/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8f8daece149ffc4a9959eae21118046
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Editor/Config/ViveProfileManager.cs
+++ b/Samples~/VIVE OpenXR Plugin/Editor/Config/ViveProfileManager.cs
@@ -1,0 +1,26 @@
+namespace Tilia.CameraRigs.OpenXR.ViveOpenXRPlugin.Config
+{
+    using Tilia.CameraRigs.OpenXR.Config;
+    using UnityEditor;
+
+    public class ViveProfileManager : OpenXRProfileManager<OpenXRProfileConfig>
+    {
+        private static readonly string _vendorName = "Vive";
+        private static string _assetPath = "Assets/OpenXRProfiles/ViveProfile.asset";
+
+        [MenuItem(menuRoot + menuConfigurePrefix + "Vive" + menuConfigureSuffix)]
+        public static void ShowWindow()
+        {
+            OpenWindow<ViveProfileManager>();
+        }
+
+        [MenuItem(menuRoot + menuSwitchPrefix + "Vive" + menuSwitchSuffix)]
+        public static void SwitchToMetaProfile()
+        {
+            SwitchProfile<OpenXRProfileConfig>(_assetPath);
+        }
+
+        protected override string GetVendorName() => _vendorName;
+        protected override string GetAssetPath() => _assetPath;
+    }
+}

--- a/Samples~/VIVE OpenXR Plugin/Editor/Config/ViveProfileManager.cs.meta
+++ b/Samples~/VIVE OpenXR Plugin/Editor/Config/ViveProfileManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01dbae7d4564e0d43bfe7d43ab9ee3ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.Editor.asmdef
+++ b/Samples~/VIVE OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:694afae57d8895748b10c4d2547d11ae"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Samples~/VIVE OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.Editor.asmdef.meta
+++ b/Samples~/VIVE OpenXR Plugin/Editor/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d901e1ea0d25dec45b613abb94ee65a9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Example.ViveProfile.asset
+++ b/Samples~/VIVE OpenXR Plugin/Example.ViveProfile.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ff2fea5ef9e79c469cd177146ab984b, type: 3}
+  m_Name: Example.ViveProfile
+  m_EditorClassIdentifier: 
+  vendorGroup: Vive
+  interactionProfiles:
+  - VIVEFocus3Profile
+  enabledFeatures:
+  - VIVEFocus3Feature
+  - VivePassthrough
+  - ViveCompositionLayer
+  - ViveCompositionLayerColorScaleBias
+  - ViveCompositionLayerCylinder

--- a/Samples~/VIVE OpenXR Plugin/Example.ViveProfile.asset.meta
+++ b/Samples~/VIVE OpenXR Plugin/Example.ViveProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 075a0a22e36d46941b06dafd2480f5e3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Runtime.meta
+++ b/Samples~/VIVE OpenXR Plugin/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8926682d5e055d4abd0b8e5ed8ae67a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.asmdef
+++ b/Samples~/VIVE OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin",
+    "rootNamespace": "",
+    "references": [
+        "GUID:fb028fe22e6301f45bc4d74d8a857779",
+        "GUID:d0a204fb2c62e9f4caca92f1c1e8c06b",
+        "GUID:4847341ff46394e83bb78fbd0652937e"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Samples~/VIVE OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.asmdef.meta
+++ b/Samples~/VIVE OpenXR Plugin/Runtime/Tilia.CameraRigs.OpenXR.Unity.ViveOpenXRPlugin.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 648968b71be32754d9d6c9c0ee05d485
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/VIVE OpenXR Plugin/Runtime/ViveUnderlayPassthroughProcessor.cs
+++ b/Samples~/VIVE OpenXR Plugin/Runtime/ViveUnderlayPassthroughProcessor.cs
@@ -1,0 +1,26 @@
+namespace Tilia.CameraRigs.OpenXR.ViveOpenXRPlugin
+{
+    using UnityEngine.XR.OpenXR;
+    public class ViveUnderlayPassthroughProcessor : PassthroughProcessor
+    {
+        private VIVE.OpenXR.Passthrough.XrPassthroughHTC id = 0;
+
+        protected override void ActivatePassthroughLogic()
+        {
+            SetSourceManagerState(false);
+            VIVE.OpenXR.Passthrough.PassthroughAPI.CreatePlanarPassthrough(out id, VIVE.OpenXR.CompositionLayer.LayerType.Underlay);
+        }
+
+        protected override void DeactivatePassthroughLogic()
+        {
+            SetSourceManagerState(false);
+            VIVE.OpenXR.Passthrough.PassthroughAPI.DestroyPassthrough(id);
+            id = 0;
+        }
+
+        protected override bool IsValid()
+        {
+            return OpenXRRuntime.name.ToLower().Contains("vive");
+        }
+    }
+}

--- a/Samples~/VIVE OpenXR Plugin/Runtime/ViveUnderlayPassthroughProcessor.cs.meta
+++ b/Samples~/VIVE OpenXR Plugin/Runtime/ViveUnderlayPassthroughProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 303c3bf4787caeb4bbcfc6682264fd6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,60 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "Runtime/**.cs"
+          ]
+        }
+      ],
+      "dest": "_TEMP_DOCS/API",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "_TEMP_DOCS/API/**.yml",
+          "_TEMP_DOCS/API/index.md"
+        ]
+      },
+      {
+        "files": [
+          "*.md"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+        ]
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [
+          "apidoc/**.md"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
+        ]
+      }
+    ],
+    "dest": "_TEMP_DOCS/output",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}

--- a/docfx.json.meta
+++ b/docfx.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1cd77cff84ff5f54b952428505f30f9b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,23 +1,29 @@
 {
-    "name": "io.extendreality.tilia.{scope}.{feature}.{platform?}",
-    "displayName": "Tilia {scope}.{feature}.{platform?}",
-    "description": "{Description of feature.}",
-    "changelogUrl": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/blob/master/CHANGELOG.md",
-    "documentationUrl": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/tree/master/Documentation",
-    "licensesUrl": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.{scope}.{feature}.{platform?}/blob/master/LICENSE.md",
+    "name": "io.extendreality.tilia.camerarigs.openxr.unity",
+    "displayName": "Tilia CameraRigs OpenXR Unity",
+    "description": "A camera rig prefab utilizing the OpenXR Framework for the Unity software.",
+    "changelogUrl": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity/blob/master/CHANGELOG.md",
+    "documentationUrl": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity/tree/master/Documentation",
+    "licensesUrl": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity/blob/master/LICENSE.md",
     "version": "1.0.0",
-    "unity": "2018.3",
-    "unityRelease": "10f1",
+    "unity": "2022.3",
+    "unityRelease": "62f1",
     "keywords": [
-        "pattern"
+        "pattern",
+        "camerarig",
+        "vr",
+        "ar",
+        "xr",
+        "openxr",
+        "spatial"
     ],
-    "homepage": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/",
+    "homepage": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity/",
     "bugs": {
-        "url": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/issues"
+        "url": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity/issues"
     },
     "repository": {
         "type": "git",
-        "url": "ssh://git@github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.git"
+        "url": "ssh://git@github.com/ExtendRealityLtd/Tilia.CameraRigs.OpenXR.Unity.git"
     },
     "license": "MIT",
     "author": {
@@ -26,7 +32,12 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "X.Y.Z"
+        "io.extendreality.zinnia.unity": "2.16.2",
+        "com.unity.xr.management": "4.0.1",
+        "com.unity.xr.legacyinputhelpers": "2.1.12",
+        "com.unity.inputsystem": "1.12.0",
+        "com.unity.xr.arfoundation": "4.2.10",
+        "com.unity.xr.openxr": "1.13.2"
     },
     "files": [
         "*.md",
@@ -34,6 +45,8 @@
         "*.asmdef",
         "*.xml",
         "Documentation",
-        "Runtime"
+        "Runtime",
+        "Editor",
+        "docfx.json"
     ]
 }

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bbb725fdd417af54bb835b02711f0b24
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The OpenXR camera rig provides a prefab that should work with any supported OpenXR vendor plugin. It needs unity to be configured for each vendor plugin and there are samples with the package to provide access to OpenXR extensions. At the moment the only extension supported is Passthrough on a basic level.

The package also contains an editor helper to allow quick switching between OpenXR profile settings in Unity as it would seem Unity does not offer this functionality, and even in Unity 6 with Build Profiles it does not seem supported.