### PR TITLE
fix(PassthroughProcessor): ensure source manager logic is called

### DIFF
--- a/Documentation/API/BasePassthroughManager.md
+++ b/Documentation/API/BasePassthroughManager.md
@@ -7,6 +7,8 @@ The base class for a Passthrough Manager
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Properties]
+  * [SourceManager]
 * [Methods]
   * [ActivatePassthrough()]
   * [DeactivatePassthrough()]
@@ -28,6 +30,18 @@ The base class for a Passthrough Manager
 
 ```
 public abstract class BasePassthroughManager : MonoBehaviour
+```
+
+### Properties
+
+#### SourceManager
+
+The source [PassthroughManager] that is controlling this processor.
+
+##### Declaration
+
+```
+public PassthroughManager SourceManager { get; set; }
 ```
 
 ### Methods
@@ -52,12 +66,14 @@ Deactivates the passthrough mode if available.
 public abstract void DeactivatePassthrough()
 ```
 
-[PassthroughManager]: PassthroughManager.md
 [PassthroughProcessor]: PassthroughProcessor.md
 [Tilia.CameraRigs.OpenXR]: README.md
+[PassthroughManager]: PassthroughManager.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Properties]: #Properties
+[SourceManager]: #SourceManager
 [Methods]: #Methods
 [ActivatePassthrough()]: #ActivatePassthrough
 [DeactivatePassthrough()]: #DeactivatePassthrough

--- a/Documentation/API/BasePassthroughManager.md.meta
+++ b/Documentation/API/BasePassthroughManager.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 27cbe644ffa51fb4dba1b566a991fd6e
+guid: 44bddc2a0d9829b4b899cee62cffa987
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Documentation/API/OpenXRNodeRecord.md.meta
+++ b/Documentation/API/OpenXRNodeRecord.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a7554f86dedc9dc439a14a37f71848cd
+guid: 746c9256d41ac1f4e9bca2ce35091141
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Documentation/API/PassthroughManager.md
+++ b/Documentation/API/PassthroughManager.md
@@ -31,6 +31,10 @@ Manages the state of camera passthrough on the device.
 * [BasePassthroughManager]
 * PassthroughManager
 
+##### Inherited Members
+
+[BasePassthroughManager.SourceManager]
+
 ##### Namespace
 
 * [Tilia.CameraRigs.OpenXR]
@@ -183,6 +187,7 @@ protected virtual void ToggleARFoundationPassthrough(bool state)
 | --- | --- | --- |
 | System.Boolean | state | n/a |
 
+[BasePassthroughManager.SourceManager]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_SourceManager
 [Tilia.CameraRigs.OpenXR]: README.md
 [PassthroughManager]: PassthroughManager.md
 [BasePassthroughManager]: BasePassthroughManager.md

--- a/Documentation/API/PassthroughManager.md.meta
+++ b/Documentation/API/PassthroughManager.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 94e97ad03c901204191de2fde928ef6a
+guid: 442501a5dac57254bacc1d167fa6a9bd
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Documentation/API/PassthroughProcessor.md
+++ b/Documentation/API/PassthroughProcessor.md
@@ -7,8 +7,6 @@ A base class to provide custom processors for vendor OpenXR extensions.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
-* [Properties]
-  * [SourceManager]
 * [Methods]
   * [ActivatePassthrough()]
   * [ActivatePassthroughLogic()]
@@ -25,6 +23,10 @@ A base class to provide custom processors for vendor OpenXR extensions.
 * [BasePassthroughManager]
 * PassthroughProcessor
 
+##### Inherited Members
+
+[BasePassthroughManager.SourceManager]
+
 ##### Namespace
 
 * [Tilia.CameraRigs.OpenXR]
@@ -33,18 +35,6 @@ A base class to provide custom processors for vendor OpenXR extensions.
 
 ```
 public abstract class PassthroughProcessor : BasePassthroughManager
-```
-
-### Properties
-
-#### SourceManager
-
-The source [PassthroughManager] that is controlling this processor.
-
-##### Declaration
-
-```
-public PassthroughManager SourceManager { get; set; }
 ```
 
 ### Methods
@@ -122,15 +112,13 @@ protected virtual void SetSourceManagerState(bool state)
 | System.Boolean | state | n/a |
 
 [BasePassthroughManager]: BasePassthroughManager.md
+[BasePassthroughManager.SourceManager]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_SourceManager
 [Tilia.CameraRigs.OpenXR]: README.md
-[PassthroughManager]: PassthroughManager.md
 [BasePassthroughManager.ActivatePassthrough()]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_ActivatePassthrough
 [BasePassthroughManager.DeactivatePassthrough()]: BasePassthroughManager.md#Tilia_CameraRigs_OpenXR_BasePassthroughManager_DeactivatePassthrough
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
-[Properties]: #Properties
-[SourceManager]: #SourceManager
 [Methods]: #Methods
 [ActivatePassthrough()]: #ActivatePassthrough
 [ActivatePassthroughLogic()]: #ActivatePassthroughLogic

--- a/Documentation/API/PassthroughProcessor.md.meta
+++ b/Documentation/API/PassthroughProcessor.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8f6ff678dfd7b01439a2d9adacce8e15
+guid: a0680393303196d4bb42f5904aff9b71
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Documentation/API/README.md.meta
+++ b/Documentation/API/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da32443d9044f9d429fc29158c872677
+guid: d36d10e7ec968f447914e288720bffcf
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Runtime/SharedResources/Scripts/PassthroughManager.cs
+++ b/Runtime/SharedResources/Scripts/PassthroughManager.cs
@@ -10,6 +10,10 @@ namespace Tilia.CameraRigs.OpenXR
     public abstract class BasePassthroughManager : MonoBehaviour
     {
         /// <summary>
+        /// The source <see cref="PassthroughManager"/> that is controlling this processor.
+        /// </summary>
+        public PassthroughManager SourceManager { get; set; }
+        /// <summary>
         /// Activates the passthrough mode if available.
         /// </summary>
         public abstract void ActivatePassthrough();
@@ -85,6 +89,7 @@ namespace Tilia.CameraRigs.OpenXR
             ApplyCameraSettings();
             foreach (BasePassthroughManager processor in passthroughManagers)
             {
+                processor.SourceManager = this;
                 processor.ActivatePassthrough();
             }
             ToggleARFoundationPassthrough(true);
@@ -98,6 +103,7 @@ namespace Tilia.CameraRigs.OpenXR
             cachedProcessPassthroughState = ProcessCameraManager;
             foreach (BasePassthroughManager processor in passthroughManagers)
             {
+                processor.SourceManager = this;
                 processor.DeactivatePassthrough();
             }
             ToggleARFoundationPassthrough(false);

--- a/Runtime/SharedResources/Scripts/PassthroughProcessor.cs
+++ b/Runtime/SharedResources/Scripts/PassthroughProcessor.cs
@@ -5,11 +5,6 @@ namespace Tilia.CameraRigs.OpenXR
     /// </summary>
     public abstract class PassthroughProcessor : BasePassthroughManager
     {
-        /// <summary>
-        /// The source <see cref="PassthroughManager"/> that is controlling this processor.
-        /// </summary>
-        public PassthroughManager SourceManager { get; set; }
-
         /// <inheritdoc/>
         public override void ActivatePassthrough()
         {


### PR DESCRIPTION
The SourceManager in the passthrough manager is supposed to allow an extended passthrough processor to halt the AR Foundation processing done by the Passthrough Manager. However, this logic was not being set so it was never being limited.

This has now been fixed so the passthrough processors do actually now control the state of the SourceManager.