### PR TITLE
fix(ProfileManager): ensure switch method is agnostic

### DIFF
--- a/Samples~/PICOOpenXRPlugin/Editor/Config/PicoProfileManager.cs
+++ b/Samples~/PICOOpenXRPlugin/Editor/Config/PicoProfileManager.cs
@@ -15,7 +15,7 @@ namespace Tilia.CameraRigs.OpenXR.PicoOpenXRPlugin.Config
         }
 
         [MenuItem(menuRoot + menuSwitchPrefix + "Pico" + menuSwitchSuffix)]
-        public static void SwitchToMetaProfile()
+        public static void SwitchToProfile()
         {
             SwitchProfile<OpenXRProfileConfig>(_assetPath);
         }

--- a/Samples~/UnityOpenXRMeta/Editor/Config/MetaProfileManager.cs
+++ b/Samples~/UnityOpenXRMeta/Editor/Config/MetaProfileManager.cs
@@ -15,7 +15,7 @@ namespace Tilia.CameraRigs.OpenXR.MetaOpenXRPlugin.Config
         }
 
         [MenuItem(menuRoot + menuSwitchPrefix + "Meta" + menuSwitchSuffix)]
-        public static void SwitchToMetaProfile()
+        public static void SwitchToProfile()
         {
             SwitchProfile<OpenXRProfileConfig>(_assetPath);
         }

--- a/Samples~/VIVEOpenXRPlugin/Editor/Config/ViveProfileManager.cs
+++ b/Samples~/VIVEOpenXRPlugin/Editor/Config/ViveProfileManager.cs
@@ -15,7 +15,7 @@ namespace Tilia.CameraRigs.OpenXR.ViveOpenXRPlugin.Config
         }
 
         [MenuItem(menuRoot + menuSwitchPrefix + "Vive" + menuSwitchSuffix)]
-        public static void SwitchToMetaProfile()
+        public static void SwitchToProfile()
         {
             SwitchProfile<OpenXRProfileConfig>(_assetPath);
         }


### PR DESCRIPTION
The Samples profile managers for each heaqdset all had a reference to Meta in their `SwitchToProfile` method, which is confusing so this has been updated so there is no reference to `Meta` in the method names at all now.